### PR TITLE
Adding filter for Endemic Countries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,6 @@ Imports:
     AzureStor
 LazyData: true
 URL: https://cdcgov.github.io/savimpx/
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/data_accessors.R
+++ b/R/data_accessors.R
@@ -6,6 +6,7 @@
 #' 
 #' @param path character string path to MPX data
 #' @param connection (optional) an `spoConnection` or `AzureStor::storage_container` object
+#' @param include_endemic (boolean, default: `TRUE`) should data from MPX endemic countries be included?
 #' 
 #' @return A data frame with n rows and 4 variables: 
 #' \itemize{
@@ -64,7 +65,9 @@
 #' @importFrom passport parse_country
 #' @importFrom AzureStor storage_download
 #' @export
-get_mpx_cases <- function(path, connection = NULL) {
+get_mpx_cases <- function(path, connection = NULL, include_endemic = TRUE) {
+
+  # Pull data using whatever method required
   raw_data <- fetch_mpx_cases(path, connection)
 
   out <- raw_data %>%
@@ -73,6 +76,12 @@ get_mpx_cases <- function(path, connection = NULL) {
       iso3code = parse_country(Country, to = "iso3c"),
       date = as.Date(date, "%m/%d/%Y")
     )
+  
+  # Filter out endemic countries, if indicated
+  if (!include_endemic) {
+    out <- out %>%
+      filter(!iso3code %in% endemic_countries[["iso3code"]])
+  }
   
   return(out)
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -21,6 +21,7 @@ reference:
 - desc: Internal Data documented
 - contents:
   - global_map
+  - endemic_countries
 
 - title: Misc
 - desc: Helper functions, internal

--- a/man/get_mpx_cases.Rd
+++ b/man/get_mpx_cases.Rd
@@ -4,12 +4,14 @@
 \alias{get_mpx_cases}
 \title{Pull MPX Case Data}
 \usage{
-get_mpx_cases(path, connection = NULL)
+get_mpx_cases(path, connection = NULL, include_endemic = TRUE)
 }
 \arguments{
 \item{path}{character string path to MPX data}
 
 \item{connection}{(optional) an \code{spoConnection} or \code{AzureStor::storage_container} object}
+
+\item{include_endemic}{(boolean, default: \code{TRUE}) should data from MPX endemic countries be included?}
 }
 \value{
 A data frame with n rows and 4 variables:

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(savimpx)
+
+test_check("savimpx")

--- a/tests/testthat/20220712-mpx-test-data.csv
+++ b/tests/testthat/20220712-mpx-test-data.csv
@@ -1,0 +1,64 @@
+﻿Country,7/11/2022
+Argentina,9
+Australia,23
+Austria,62
+Bahamas,1
+Belgium,168
+Benin,3
+Brazil,218
+Bulgaria,3
+Cameroon,3
+Canada,375
+Central African Republic,8
+Chile,13
+Colombia,6
+Croatia,1
+Czechia,11
+Democratic Republic of the Congo,107
+Denmark,29
+Dominican Republic,1
+Ecuador,1
+Estonia,2
+Finland,13
+France,721
+Georgia,1
+Germany,1556
+Ghana,19
+Gibraltar,1
+Greece,11
+Hungary,24
+Iceland,6
+Ireland,44
+Israel,66
+Italy,255
+Jamaica,1
+Latvia,2
+Lebanon,1
+Luxembourg,6
+Malta,8
+Mexico,35
+Morocco,1
+Netherlands,503
+Nigeria,84
+Norway,19
+Panama,1
+Peru,18
+Poland,19
+Portugal,473
+Republic of the Congo,2
+Romania,14
+Serbia,1
+Singapore,2
+Slovakia,1
+Slovenia,18
+South Africa,3
+South Korea,1
+Spain,2034
+Sweden,43
+Switzerland,163
+Taiwan,1
+Turkey,1
+United Arab Emirates,13
+United Kingdom,1552
+United States,865
+Venezuela,1

--- a/tests/testthat/test-get_mpx_cases.R
+++ b/tests/testthat/test-get_mpx_cases.R
@@ -1,0 +1,19 @@
+test_that("Endemic Countries are filtered correctly", {
+  # Read in test data
+  test_data_path <- file.path("20220712-mpx-test-data.csv")
+  # -- Including Endemic Countries
+  endemic <- get_mpx_cases(test_data_path, include_endemic = TRUE)
+
+  any_endemic <- any(endemic[["iso3code"]] %in% endemic_countries[["iso3code"]])
+
+  # Expect that Endemic countries are included if requested
+  expect_true(any_endemic)
+
+  # -- Excluding Endemic Countries
+  non_endemic <- get_mpx_cases(test_data_path, include_endemic = FALSE)
+
+  any_endemic <- any(non_endemic[["iso3code"]] %in% endemic_countries[["iso3code"]])
+
+  # Expect that endemic countries are excluded if requested
+  expect_false(any_endemic)
+})


### PR DESCRIPTION
## Changes
- Adds `include_endemic` argument to `get_mpx_cases()`
- Updated docs
- Added unittest